### PR TITLE
Allow procurement staff to add suppliers

### DIFF
--- a/src/main/java/com/polatholding/procurementsystem/config/security/SecurityHelper.java
+++ b/src/main/java/com/polatholding/procurementsystem/config/security/SecurityHelper.java
@@ -1,0 +1,34 @@
+package com.polatholding.procurementsystem.config.security;
+
+import com.polatholding.procurementsystem.model.User;
+import com.polatholding.procurementsystem.repository.UserRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component("securityHelper")
+public class SecurityHelper {
+
+    private final UserRepository userRepository;
+
+    public SecurityHelper(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public boolean isProcurementStaff(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        String email = authentication.getName();
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        boolean isProcurementManager = user.getRoles().stream()
+                .anyMatch(r -> "ProcurementManager".equals(r.getRoleName()));
+        boolean isProcurementEmployee = user.getRoles().stream()
+                .anyMatch(r -> "Employee".equals(r.getRoleName())) &&
+                user.getDepartment() != null &&
+                "Procurement".equals(user.getDepartment().getDepartmentName());
+        return isProcurementManager || isProcurementEmployee;
+    }
+}

--- a/src/main/java/com/polatholding/procurementsystem/controller/ReportController.java
+++ b/src/main/java/com/polatholding/procurementsystem/controller/ReportController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/reports")
-@PreAuthorize("hasAnyRole('Finance', 'ProcurementManager')")
+@PreAuthorize("hasAnyRole('Finance Officer', 'ProcurementManager')")
 public class ReportController {
 
     private final ReportService reportService;

--- a/src/main/java/com/polatholding/procurementsystem/controller/SupplierController.java
+++ b/src/main/java/com/polatholding/procurementsystem/controller/SupplierController.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Controller
 @RequestMapping("/suppliers")
-@PreAuthorize("hasRole('ProcurementManager')")
 public class SupplierController {
 
     private final SupplierService supplierService;
@@ -44,12 +43,14 @@ public class SupplierController {
     }
 
     @GetMapping("/new")
+    @PreAuthorize("@securityHelper.isProcurementStaff(authentication)")
     public String showNewSupplierForm(Model model) {
         model.addAttribute("supplierFormDto", new SupplierFormDto());
         return "supplier-form";
     }
 
     @PostMapping("/save")
+    @PreAuthorize("@securityHelper.isProcurementStaff(authentication)")
     public String saveNewSupplier(@Valid @ModelAttribute("supplierFormDto") SupplierFormDto formDto,
                                   BindingResult bindingResult,
                                   RedirectAttributes redirectAttributes) {
@@ -62,6 +63,7 @@ public class SupplierController {
     }
 
     @PostMapping("/approve/{id}")
+    @PreAuthorize("hasRole('ProcurementManager')")
     public String approveSupplier(@PathVariable("id") Integer id, RedirectAttributes redirectAttributes) {
         supplierService.approveSupplier(id);
         redirectAttributes.addFlashAttribute("successMessage", "Supplier approved and is now active.");
@@ -69,6 +71,7 @@ public class SupplierController {
     }
 
     @PostMapping("/reject/{id}")
+    @PreAuthorize("hasRole('ProcurementManager')")
     public String rejectSupplier(@PathVariable("id") Integer id, RedirectAttributes redirectAttributes) {
         supplierService.rejectSupplier(id);
         redirectAttributes.addFlashAttribute("successMessage", "Supplier has been rejected.");

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -18,7 +18,7 @@
             <a th:href="@{/approvals}">Approvals</a>
         </li>
         <li class="nav-item" th:classappend="${#strings.startsWith(currentUrl, '/suppliers')} ? 'active' : ''"
-            sec:authorize="hasAnyRole('ProcurementManager', 'Employee')">
+            sec:authorize="isAuthenticated()">
             <a th:href="@{/suppliers}">Suppliers</a>
         </li>
         <li class="nav-item" th:classappend="${#strings.startsWith(currentUrl, '/budgets')} ? 'active' : ''"

--- a/src/main/resources/templates/suppliers.html
+++ b/src/main/resources/templates/suppliers.html
@@ -31,7 +31,8 @@
         <!-- Page Content -->
         <div class="page-content">
             <div style="margin-bottom: 20px; text-align: right;">
-                <a th:href="@{/suppliers/new}" class="btn btn-primary">Add New Supplier</a>
+                <a th:href="@{/suppliers/new}" class="btn btn-primary"
+                   sec:authorize="@securityHelper.isProcurementStaff(authentication)">Add New Supplier</a>
             </div>
 
             <div th:if="${successMessage}" class="alert-flash alert-success-flash" th:text="${successMessage}"></div>


### PR DESCRIPTION
## Summary
- relax access restriction on SupplierController so procurement employees can add suppliers
- restrict approval/rejection to Procurement Managers only
- let Finance Officers access the reports tab
- hide Add Supplier option from non-procurement employees

## Testing
- `bash ./mvnw -q test` *(fails: unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6847122551c08333ab0974aed97833f4