### PR TITLE
Fix UI issues and department management

### DIFF
--- a/src/main/java/com/polatholding/procurementsystem/controller/DepartmentController.java
+++ b/src/main/java/com/polatholding/procurementsystem/controller/DepartmentController.java
@@ -74,4 +74,15 @@ public class DepartmentController {
         redirectAttributes.addFlashAttribute("successMessage", "Department updated successfully.");
         return "redirect:/admin/departments";
     }
+
+    @PostMapping("/delete/{id}")
+    public String deleteDepartment(@PathVariable("id") Integer id, RedirectAttributes redirectAttributes) {
+        try {
+            departmentService.deleteDepartment(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Department deleted successfully.");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/admin/departments";
+    }
 }

--- a/src/main/java/com/polatholding/procurementsystem/dto/SupplierDto.java
+++ b/src/main/java/com/polatholding/procurementsystem/dto/SupplierDto.java
@@ -9,6 +9,6 @@ public class SupplierDto {
     private String contactPerson;
     private String email;
     private String phone;
-    private String address;
+    private String description;
     private String status;
 }

--- a/src/main/java/com/polatholding/procurementsystem/dto/SupplierFormDto.java
+++ b/src/main/java/com/polatholding/procurementsystem/dto/SupplierFormDto.java
@@ -24,6 +24,6 @@ public class SupplierFormDto {
     @Size(max = 30, message = "Phone number cannot exceed 30 characters.")
     private String phone;
 
-    @Size(max = 200, message = "Address cannot exceed 200 characters.")
-    private String address;
+    @Size(max = 200, message = "Description cannot exceed 200 characters.")
+    private String description;
 }

--- a/src/main/java/com/polatholding/procurementsystem/model/Supplier.java
+++ b/src/main/java/com/polatholding/procurementsystem/model/Supplier.java
@@ -29,8 +29,8 @@ public class Supplier {
     @Column(name = "Phone", length = 30)
     private String phone;
 
-    @Column(name = "Address", length = 200)
-    private String address;
+    @Column(name = "Description", length = 200)
+    private String description;
 
     @Column(name = "Status", nullable = false, length = 20)
     private String status;

--- a/src/main/java/com/polatholding/procurementsystem/repository/DatabaseHelperRepositoryImpl.java
+++ b/src/main/java/com/polatholding/procurementsystem/repository/DatabaseHelperRepositoryImpl.java
@@ -30,7 +30,10 @@ public class DatabaseHelperRepositoryImpl implements DatabaseHelperRepository {
 
     @Override
     public void addUser(String firstName, String lastName, String email, String passwordHash, Integer departmentId) {
-        jdbcTemplate.update("EXEC sp_AddUser ?,?,?,?,?", firstName, lastName, email, passwordHash, departmentId);
+        jdbcTemplate.update("EXEC sp_AddUser ?,?,?,?", firstName, lastName, email, passwordHash);
+        if (departmentId != null) {
+            jdbcTemplate.update("UPDATE Users SET DepartmentID=? WHERE Email=?", departmentId, email);
+        }
     }
 
     @Override

--- a/src/main/java/com/polatholding/procurementsystem/repository/SupplierRepository.java
+++ b/src/main/java/com/polatholding/procurementsystem/repository/SupplierRepository.java
@@ -16,7 +16,7 @@ public interface SupplierRepository extends JpaRepository<Supplier, Integer> {
     List<Supplier> findByStatusOrderBySupplierNameAsc(String status);
 
     @Query(value = "SELECT s.* FROM Suppliers s " +
-            "WHERE FREETEXT((s.SupplierName, s.ContactPerson, s.Address), :searchTerm) " +
+            "WHERE FREETEXT((s.SupplierName, s.ContactPerson, s.Description), :searchTerm) " +
             "AND s.Status = 'Active'",
             nativeQuery = true)
     List<Supplier> searchByFreetext(@Param("searchTerm") String searchTerm);

--- a/src/main/java/com/polatholding/procurementsystem/repository/UserRepository.java
+++ b/src/main/java/com/polatholding/procurementsystem/repository/UserRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
     List<User> findByRolesContaining(Role role); // New method
+
+    boolean existsByDepartment_DepartmentIdAndFormerEmployeeFalse(Integer departmentId);
 }

--- a/src/main/java/com/polatholding/procurementsystem/service/AdminServiceImpl.java
+++ b/src/main/java/com/polatholding/procurementsystem/service/AdminServiceImpl.java
@@ -36,6 +36,8 @@ public class AdminServiceImpl implements AdminService {
     // Department Names - Ensure these EXACTLY match DepartmentName in your Departments TABLE
     private static final String PROCUREMENT_DEPARTMENT_NAME = "Procurement";
     public static final String FINANCE_DEPARTMENT_NAME = "Finance";
+    public static final String ADMIN_DEPARTMENT_NAME = "Administration";
+    public static final String AUDIT_DEPARTMENT_NAME = "Audit";
 
     // Other Role Names
     static final String MANAGER_ROLE_NAME = "Manager"; // Base Manager role
@@ -137,14 +139,23 @@ public class AdminServiceImpl implements AdminService {
         Role finalRoleToAssign = originallySelectedRoleOnForm;
         String selectedRoleName = originallySelectedRoleOnForm.getRoleName();
 
-        if (AUDITOR_ROLE_NAME.equals(selectedRoleName) ||
-                DIRECTOR_ROLE_NAME.equals(selectedRoleName) ||
-                ADMIN_ROLE_NAME.equals(selectedRoleName)) {
-            System.out.println("DEBUG createUser: Matched a global role: " + selectedRoleName);
+        if (DIRECTOR_ROLE_NAME.equals(selectedRoleName)) {
+            System.out.println("DEBUG createUser: Director role - no department.");
             finalDepartmentToAssign = null;
-            if (userFormDto.getDepartmentId() != null) {
-                System.out.println("WARN createUser: Department selection '" + userFormDto.getDepartmentId() + "' ignored for global role: " + selectedRoleName);
-            }
+        }
+        else if (ADMIN_ROLE_NAME.equals(selectedRoleName)) {
+            Department adminDept = departmentRepository.findAll().stream()
+                    .filter(d -> ADMIN_DEPARTMENT_NAME.equals(d.getDepartmentName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Critical: 'Administration' department not found."));
+            finalDepartmentToAssign = adminDept;
+        }
+        else if (AUDITOR_ROLE_NAME.equals(selectedRoleName)) {
+            Department auditDept = departmentRepository.findAll().stream()
+                    .filter(d -> AUDIT_DEPARTMENT_NAME.equals(d.getDepartmentName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Critical: 'Audit' department not found."));
+            finalDepartmentToAssign = auditDept;
         }
         else if (FINANCE_ROLE_NAME.equals(selectedRoleName)) {
             System.out.println("DEBUG createUser: Matched FINANCE_ROLE_NAME ('" + selectedRoleName + "'). Forcing Finance department.");
@@ -286,11 +297,23 @@ public class AdminServiceImpl implements AdminService {
         Role finalRoleToAssign = originallySelectedRoleOnForm;
         String selectedRoleName = originallySelectedRoleOnForm.getRoleName();
 
-        if (AUDITOR_ROLE_NAME.equals(selectedRoleName) ||
-                DIRECTOR_ROLE_NAME.equals(selectedRoleName) ||
-                ADMIN_ROLE_NAME.equals(selectedRoleName)) {
-            System.out.println("DEBUG updateUser: Matched a global role: " + selectedRoleName);
+        if (DIRECTOR_ROLE_NAME.equals(selectedRoleName)) {
+            System.out.println("DEBUG updateUser: Director role - no department.");
             finalDepartmentToAssign = null;
+        }
+        else if (ADMIN_ROLE_NAME.equals(selectedRoleName)) {
+            Department adminDept = departmentRepository.findAll().stream()
+                    .filter(d -> ADMIN_DEPARTMENT_NAME.equals(d.getDepartmentName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Critical: 'Administration' department not found."));
+            finalDepartmentToAssign = adminDept;
+        }
+        else if (AUDITOR_ROLE_NAME.equals(selectedRoleName)) {
+            Department auditDept = departmentRepository.findAll().stream()
+                    .filter(d -> AUDIT_DEPARTMENT_NAME.equals(d.getDepartmentName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Critical: 'Audit' department not found."));
+            finalDepartmentToAssign = auditDept;
         }
         else if (FINANCE_ROLE_NAME.equals(selectedRoleName)) {
             System.out.println("DEBUG updateUser: Matched FINANCE_ROLE_NAME. Forcing Finance department.");

--- a/src/main/java/com/polatholding/procurementsystem/service/DepartmentService.java
+++ b/src/main/java/com/polatholding/procurementsystem/service/DepartmentService.java
@@ -10,4 +10,5 @@ public interface DepartmentService {
     void createDepartment(DepartmentFormDto formDto);
     DepartmentFormDto getDepartmentFormById(Integer id);
     void updateDepartment(Integer id, DepartmentFormDto formDto);
+    void deleteDepartment(Integer id);
 }

--- a/src/main/java/com/polatholding/procurementsystem/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/polatholding/procurementsystem/service/DepartmentServiceImpl.java
@@ -4,6 +4,7 @@ import com.polatholding.procurementsystem.dto.DepartmentDto;
 import com.polatholding.procurementsystem.dto.DepartmentFormDto;
 import com.polatholding.procurementsystem.model.Department;
 import com.polatholding.procurementsystem.repository.DepartmentRepository;
+import com.polatholding.procurementsystem.repository.UserRepository;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +16,12 @@ import java.util.stream.Collectors;
 public class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
+    private final UserRepository userRepository;
 
-    public DepartmentServiceImpl(DepartmentRepository departmentRepository) {
+    public DepartmentServiceImpl(DepartmentRepository departmentRepository,
+                                 UserRepository userRepository) {
         this.departmentRepository = departmentRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -54,6 +58,15 @@ public class DepartmentServiceImpl implements DepartmentService {
         dept.setDepartmentName(formDto.getDepartmentName());
         dept.setManagerUserId(formDto.getManagerUserId());
         departmentRepository.save(dept);
+    }
+
+    @Override
+    @Transactional
+    public void deleteDepartment(Integer id) {
+        if (userRepository.existsByDepartment_DepartmentIdAndFormerEmployeeFalse(id)) {
+            throw new IllegalStateException("Department has active employees.");
+        }
+        departmentRepository.deleteById(id);
     }
 
     private DepartmentDto convertToDto(Department department) {

--- a/src/main/java/com/polatholding/procurementsystem/service/SupplierServiceImpl.java
+++ b/src/main/java/com/polatholding/procurementsystem/service/SupplierServiceImpl.java
@@ -105,7 +105,7 @@ public class SupplierServiceImpl implements SupplierService {
         supplierToUpdate.setContactPerson(formDto.getContactPerson());
         supplierToUpdate.setEmail(formDto.getEmail());
         supplierToUpdate.setPhone(formDto.getPhone());
-        supplierToUpdate.setAddress(formDto.getAddress());
+        supplierToUpdate.setDescription(formDto.getDescription());
         supplierRepository.save(supplierToUpdate);
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -119,32 +119,6 @@ body {
     color: var(--polat-accent-blue);
 }
 
-.form-options {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 30px;
-    font-size: 14px;
-}
-
-.form-options .remember-me {
-    display: flex;
-    align-items: center;
-}
-
-.form-options label {
-    margin-left: 5px;
-    color: #666;
-}
-
-.form-options a {
-    color: var(--polat-accent-blue);
-    text-decoration: none;
-}
-
-.form-options a:hover {
-    text-decoration: underline;
-}
 
 .btn-login {
     width: 100%;
@@ -445,6 +419,7 @@ body {
     width: 100%;
     border-collapse: collapse;
     margin-top: 15px;
+    table-layout: fixed;
 }
 .item-table th, .item-table td {
     padding: 8px;
@@ -460,6 +435,7 @@ body {
     padding: 8px;
     border: 1px solid #ced4da;
     border-radius: 4px;
+    min-width: 0;
 }
 .item-table td.actions-cell {
     width: 100px;

--- a/src/main/resources/templates/admin-departments.html
+++ b/src/main/resources/templates/admin-departments.html
@@ -65,6 +65,9 @@
                     <td th:text="${dept.departmentName}"></td>
                     <td>
                         <a th:href="@{/admin/departments/edit/{id}(id=${dept.departmentId})}" class="btn btn-warning btn-sm">Edit</a>
+                        <form th:action="@{/admin/departments/delete/{id}(id=${dept.departmentId})}" method="post" style="display:inline;">
+                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Delete department?');">Delete</button>
+                        </form>
                     </td>
                 </tr>
                 </tbody>

--- a/src/main/resources/templates/admin-user-form.html
+++ b/src/main/resources/templates/admin-user-form.html
@@ -159,6 +159,8 @@
     const ADMIN_ROLE_NAME_JS = /*[[${T(com.polatholding.procurementsystem.service.AdminServiceImpl).ADMIN_ROLE_NAME}]]*/ 'Admin';
     const FINANCE_ROLE_NAME_JS = /*[[${T(com.polatholding.procurementsystem.service.AdminServiceImpl).FINANCE_ROLE_NAME}]]*/ 'Finance Officer'; // Ensure this matches the constant
     const FINANCE_DEPARTMENT_NAME_JS = /*[[${T(com.polatholding.procurementsystem.service.AdminServiceImpl).FINANCE_DEPARTMENT_NAME}]]*/ 'Finance';
+    const ADMIN_DEPARTMENT_NAME_JS = /*[[${T(com.polatholding.procurementsystem.service.AdminServiceImpl).ADMIN_DEPARTMENT_NAME}]]*/ 'Administration';
+    const AUDIT_DEPARTMENT_NAME_JS = /*[[${T(com.polatholding.procurementsystem.service.AdminServiceImpl).AUDIT_DEPARTMENT_NAME}]]*/ 'Audit';
 
     const allRolesJs = /*[[${allRoles}]]*/ [];
     const allDepartmentsJs = /*[[${departments}]]*/ [];
@@ -183,13 +185,36 @@
             }
         });
 
-        const isGlobalRole = [AUDITOR_ROLE_NAME_JS, DIRECTOR_ROLE_NAME_JS, ADMIN_ROLE_NAME_JS].includes(selectedRoleName);
         const isFinanceRole = selectedRoleName === FINANCE_ROLE_NAME_JS;
 
-        if (isGlobalRole) {
+        if (selectedRoleName === DIRECTOR_ROLE_NAME_JS) {
             departmentDropdown.value = '';
             departmentDropdown.disabled = true;
             departmentDropdown.required = false;
+        } else if (selectedRoleName === ADMIN_ROLE_NAME_JS) {
+            let deptId = null;
+            allDepartmentsJs.forEach(function(dept) {
+                if (dept.departmentName === ADMIN_DEPARTMENT_NAME_JS) {
+                    deptId = dept.departmentId;
+                }
+            });
+            if (deptId) {
+                departmentDropdown.value = deptId;
+                departmentDropdown.disabled = true;
+                departmentDropdown.required = true;
+            }
+        } else if (selectedRoleName === AUDITOR_ROLE_NAME_JS) {
+            let deptId = null;
+            allDepartmentsJs.forEach(function(dept) {
+                if (dept.departmentName === AUDIT_DEPARTMENT_NAME_JS) {
+                    deptId = dept.departmentId;
+                }
+            });
+            if (deptId) {
+                departmentDropdown.value = deptId;
+                departmentDropdown.disabled = true;
+                departmentDropdown.required = true;
+            }
         } else if (isFinanceRole) {
             let financeDeptId = null;
             allDepartmentsJs.forEach(function(dept) {

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -28,8 +28,8 @@
             sec:authorize="hasAnyRole('Finance Officer', 'Auditor')">
             <a th:href="@{/budgets}">Budgets</a>
         </li>
-        <li class="nav-item" th:classappend="${#strings.startsWith(currentUrl, '/reports')} ? 'active' : ''"
-            sec:authorize="hasAnyRole('Finance Officer', 'ProcurementManager', 'Auditor')">
+        <li class="nav-item" th:classappend="${#strings.startsWith(currentUrl, '/reports')} ? 'active' : ''" 
+            sec:authorize="hasAnyRole('Finance Officer', 'ProcurementManager', 'Auditor', 'Director')">
             <a th:href="@{/reports/budget-status}">Reports</a>
         </li>
         <li class="nav-item" th:classappend="${#strings.startsWith(currentUrl, '/admin/users')} ? 'active' : ''"

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -39,13 +39,7 @@
                     <input type="password" id="password" name="password" required="required">
                     <label for="password">Password</label>
                 </div>
-                <div class="form-options">
-                    <div class="remember-me">
-                        <input type="checkbox" id="remember-me" name="remember-me">
-                        <label for="remember-me">Remember Me</label>
-                    </div>
-                    <a href="#">Forgot Password?</a>
-                </div>
+                <!-- Removed Remember Me and Forgot Password links -->
                 <button type="submit" class="btn-login">LOGIN</button>
             </form>
         </div>

--- a/src/main/resources/templates/supplier-form.html
+++ b/src/main/resources/templates/supplier-form.html
@@ -89,11 +89,11 @@
                     </div>
 
                     <div class="form-section">
-                        <h3>Address Information</h3>
+                        <h3>Description</h3>
                         <div class="form-group">
-                            <label for="address">Address</label>
-                            <textarea id="address" th:field="*{address}" rows="3" style="min-height: auto; resize: vertical;"></textarea>
-                            <small class="text-danger" th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></small>
+                            <label for="description">Description</label>
+                            <textarea id="description" th:field="*{description}" rows="3" style="min-height: auto; resize: vertical;"></textarea>
+                            <small class="text-danger" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></small>
                         </div>
                     </div>
 

--- a/src/main/resources/templates/suppliers.html
+++ b/src/main/resources/templates/suppliers.html
@@ -18,7 +18,7 @@
             <h1>Supplier Management</h1>
             <div class="search-container">
                 <form th:action="@{/suppliers}" method="get" class="search-form">
-                    <input type="search" name="q" placeholder="Search suppliers by name, contact, or address..." class="search-input" th:value="${searchTerm}" required>
+                    <input type="search" name="q" placeholder="Search suppliers by name, contact, or description..." class="search-input" th:value="${searchTerm}" required>
                     <button type="submit" class="search-button">Search</button>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- rename Supplier address field to description
- allow Director to access reports
- remove Remember Me and Forgot Password from login page
- prevent input overflow in request item table
- enable department deletion with active employee check
- adjust user creation stored procedure call
- auto-select departments based on role during user management

## Testing
- `./mvnw -q -DskipTests install` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6850c38624188333977aa48c4dcf0aad